### PR TITLE
show confirmation dialoge on delete key keyboard shortcut press

### DIFF
--- a/pages/board/[id].client.vue
+++ b/pages/board/[id].client.vue
@@ -98,14 +98,14 @@ onUnmounted(() => {
 });
 
 // Initialize global shortcuts
+const showDeleteConfirmation = () => {
+    if (boardStore.selectedId) {
+        deleteItemConfirm.value = true;
+    }
+};
+
 useGlobalShortcuts({
-    handleDelete,
-    handleDelete: () => {
-        // Show confirmation dialog when Delete key is pressed
-        if (boardStore.selectedId) {
-            deleteItemConfirm.value = true;
-        }
-    },
+    handleDelete: showDeleteConfirmation,
     handlePaste,
 });
 
@@ -219,7 +219,7 @@ const updateDisplayName = (id: string, displayName: string) => {
                                 updateItemPosition(item.id, updates)
                         "
                         :shadow="item.kind !== 'text'"
-                        @delete="deleteItemConfirm = true"
+                        @delete="showDeleteConfirmation"
                         @lock="(locked: boolean) => toggleLock(item.id, locked)"
                         v-slot="{ startMove }"
                         @update:displayName="

--- a/pages/board/[id].client.vue
+++ b/pages/board/[id].client.vue
@@ -100,6 +100,12 @@ onUnmounted(() => {
 // Initialize global shortcuts
 useGlobalShortcuts({
     handleDelete,
+    handleDelete: () => {
+        // Show confirmation dialog when Delete key is pressed
+        if (boardStore.selectedId) {
+            deleteItemConfirm.value = true;
+        }
+    },
     handlePaste,
 });
 


### PR DESCRIPTION
show confirmation dialoge on delete key keyboard shortcut press

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Pressing the Delete key now opens a confirmation dialog before deleting a selected item on the board.

- **Style**
	- No visible style changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->